### PR TITLE
Fix error if for mhcii no strong binders are found 

### DIFF
--- a/novumRNA_modules.nf
+++ b/novumRNA_modules.nf
@@ -682,7 +682,7 @@ process 'Final_MHCII' {
   --BED_2 $bed_2 --Specific $specific --BIND $bind --Out "${meta.ID}_final_out_combined_1.tsv" \
   --Out_header "${meta.ID}_final_out_combined_0.tsv"
 
-  if [ -s "${meta.ID}_final_out_combined_1.tsv"]; then
+  if [ -s "${meta.ID}_final_out_combined_1.tsv" ]; then
   
   /bedtools2/bin/bedtools intersect -wao -s -a "${meta.ID}_final_out_combined_1.tsv" \
   -b $anno_2 > "${meta.ID}_final_out_combined_2.tsv"
@@ -691,7 +691,7 @@ process 'Final_MHCII' {
   --BED_old "${meta.ID}_final_out_combined_0.tsv" --Out "${meta.ID}_final_class_II_prediction.tsv"
 
   else 
-    touch "${meta.ID}_final_class_II_prediction.tsv"
+    echo \"No ClassII peptides found \" > "${meta.ID}_final_class_II_prediction.tsv"
   fi
     """
 }

--- a/novumRNA_modules.nf
+++ b/novumRNA_modules.nf
@@ -681,12 +681,18 @@ process 'Final_MHCII' {
   /scripts/final_out_2.py --Filtering $filtering --VAF $vaf --BED $bed --Translation $translation \
   --BED_2 $bed_2 --Specific $specific --BIND $bind --Out "${meta.ID}_final_out_combined_1.tsv" \
   --Out_header "${meta.ID}_final_out_combined_0.tsv"
+
+  if [ -s "${meta.ID}_final_out_combined_1.tsv"]; then
   
   /bedtools2/bin/bedtools intersect -wao -s -a "${meta.ID}_final_out_combined_1.tsv" \
   -b $anno_2 > "${meta.ID}_final_out_combined_2.tsv"
   
   /scripts/final_out_1.py --BED "${meta.ID}_final_out_combined_2.tsv" \
   --BED_old "${meta.ID}_final_out_combined_0.tsv" --Out "${meta.ID}_final_class_II_prediction.tsv"
+
+  else 
+    touch "${meta.ID}_final_class_II_prediction.tsv"
+  fi
     """
 }
 

--- a/novumRNA_modules.nf
+++ b/novumRNA_modules.nf
@@ -637,7 +637,8 @@ process 'Collect_binding' {
     
   script:
     """
-   head -2 *01_peptides_I_binding.tsv > "${meta.ID}_final_I_out.tsv"; \
+   HEADER_FILE=\$(ls *_peptides_I_binding.tsv | head -n 1) 
+   head -2 \$HEADER_FILE > "${meta.ID}_final_I_out.tsv"; \
    tail -n +3 -q *_peptides_I_binding.tsv >> "${meta.ID}_final_I_out.tsv"
     """
 }
@@ -708,8 +709,9 @@ process 'Collect_binding_II' {
     
   script:
     """
-   head -2 *01_peptides_II_binding.tsv > "${meta.ID}_final_II_out.tsv"; tail \
-   -n +3 -q *_peptides_II_binding.tsv >> "${meta.ID}_final_II_out.tsv"
+   HEADER_FILE=\$(ls *_peptides_II_binding.tsv | head -n 1) 
+   head -2 \$HEADER_FILE > "${meta.ID}_final_II_out.tsv"; \
+   tail -n +3 -q *_peptides_II_binding.tsv >> "${meta.ID}_final_II_out.tsv"
     """
 }
 


### PR DESCRIPTION
fix for issues which occur if no MHCII class antigens with binding rank < 2 are in a samples.
Additionally fixing Collect_binding for cases if no *01_peptides_I_binding.tsv is present just with files with higher numbers